### PR TITLE
fix: wire swift-crypto for cross-compiled targets (Android/Linux)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,6 @@
 
 import CompilerPluginSupport
 import PackageDescription
-import Foundation
 
 // MARK: - Products
 
@@ -52,15 +51,17 @@ var dependencies: [Package.Dependency] = [
 	)
 ]
 
-// Add swift-crypto on Linux (CryptoKit is built-in on Apple platforms)
-#if os(Linux)
-	dependencies.append(
-		.package(
-			url: "https://github.com/apple/swift-crypto.git",
-			from: "3.0.0"
-		)
+// swift-crypto backs `import Crypto` on platforms without a built-in CryptoKit (Linux, Android).
+// Declared UNCONDITIONALLY: a package manifest's `#if os(...)` reflects the build *host*, not the
+// target, so the old `#if os(Linux)` never fired when cross-compiling from an Apple host (which
+// broke Android and cross-built Linux alike). The product is only *linked* where needed — see
+// the `.when(platforms:)` condition in businessMathDeps below — so Apple builds pay no cost.
+dependencies.append(
+	.package(
+		url: "https://github.com/apple/swift-crypto.git",
+		from: "3.0.0"
 	)
-#endif
+)
 
 // MARK: - Targets
 
@@ -70,12 +71,16 @@ var businessMathDeps: [Target.Dependency] = [
 	.product(name: "Collections", package: "swift-collections")
 ]
 
-// Add Crypto on Linux (CryptoKit built-in on Apple platforms)
-#if os(Linux)
-	businessMathDeps.append(
-		.product(name: "Crypto", package: "swift-crypto")
+// Link swift-crypto's Crypto only where CryptoKit is absent. `.when(platforms:)` is evaluated
+// against the TARGET triple, so it works under cross-compilation — unlike the host-based
+// `#if os(Linux)` it replaces. Apple targets keep using built-in CryptoKit via `canImport`.
+businessMathDeps.append(
+	.product(
+		name: "Crypto",
+		package: "swift-crypto",
+		condition: .when(platforms: [.linux, .android])
 	)
-#endif
+)
 
 var targets: [Target] = [
 


### PR DESCRIPTION
## Problem
A package manifest's `#if os(...)` evaluates against the **build host**, not the target. So the previous `#if os(Linux)` guards around swift-crypto never fired when cross-compiling from an Apple host — swift-crypto was never wired in, and `TemplateRegistry.swift`'s `#else import Crypto` failed with `no such module 'Crypto'` on Android (and on cross-built Linux).

## Fix
- Declare swift-crypto **unconditionally** in `dependencies`.
- Attach the `Crypto` product via `.when(platforms: [.linux, .android])`, which is evaluated against the **target** triple. Apple targets keep using built-in CryptoKit via `canImport`, so they link nothing new.
- Drop the vestigial `import Foundation` from the manifest (unused; it hangs manifest compilation under the swift-6.2 toolchain on a macOS 27/28 beta host).

## Validation
`swift package dump-package` confirms swift-crypto is wired and the `Crypto` product carries the `[linux, android]` platform condition. Verified while cross-compiling BioFeedbackKit to `aarch64-unknown-linux-android24`: with this change the manifest resolves and BusinessMath compiles for Android (prior failure was `no such module 'Crypto'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)