### PR TITLE
fix: use portable .squareRoot() instead of free sqrt() for Android

### DIFF
--- a/Sources/BusinessMath/Simulation/distributionTriangular.swift
+++ b/Sources/BusinessMath/Simulation/distributionTriangular.swift
@@ -52,10 +52,10 @@ public func triangularDistribution<T: Real>(low a: T, high b: T, base c: T, _ uS
 	let u = T(uInt) / T(1_000_000) // fp-safety:disable — constant 1_000_000
     if u > 0 && u < fc {
         let s = u * (b - a) * (c - a)
-        return a + sqrt(s)
+        return a + s.squareRoot()
     } else {
         let s = (1 - u) * (b - a) * (b - c)
-        return b - sqrt(s)
+        return b - s.squareRoot()
     }
 }
 

--- a/Sources/BusinessMath/Statistics/Comparison Statistics/nemenyiCD.swift
+++ b/Sources/BusinessMath/Statistics/Comparison Statistics/nemenyiCD.swift
@@ -107,7 +107,7 @@ public func nemenyiCD(judges: Int, items: Int, alpha: Double) -> Float {
     let k = Float(items)
     let n = Float(judges)
     let fraction = (k * (k + 1)) / (6 * n)
-    let cd = q * sqrt(fraction)
+    let cd = q * fraction.squareRoot()
 
     return cd
 }

--- a/Sources/BusinessMath/Statistics/Regression/MatrixOperations/DenseMatrix.swift
+++ b/Sources/BusinessMath/Statistics/Regression/MatrixOperations/DenseMatrix.swift
@@ -324,7 +324,7 @@ public struct DenseMatrix<T: Real>: Sendable where T: Sendable {
                 sumSquares += data[i][j] * data[i][j]
             }
         }
-        return sqrt(sumSquares)
+        return sumSquares.squareRoot()
     }
 
     // MARK: - Basic Operations

--- a/Sources/BusinessMath/Time Series/Growth/TrendModel.swift
+++ b/Sources/BusinessMath/Time Series/Growth/TrendModel.swift
@@ -465,7 +465,7 @@ public struct LinearTrend<T: Real & Sendable>: TrendModel, Sendable {
 		let sumSquaredResiduals = residuals.map { $0 * $0 }.reduce(T.zero, +)
 		let degreesOfFreedom = max(residuals.count - 2, 1)  // -2 for slope and intercept
 		let mse = sumSquaredResiduals / T(degreesOfFreedom)
-		let standardError = sqrt(mse)
+		let standardError = mse.squareRoot()
 
 		// Get z-score for confidence level using built-in function
 		let zScoreValue = zScore(ci: confidenceLevel)
@@ -485,7 +485,7 @@ public struct LinearTrend<T: Real & Sendable>: TrendModel, Sendable {
 			let term1 = T(1)
 			let term2 = T(1) / n
 			let term3 = (horizon * horizon) / (T(12) * n)
-			let varianceFactor = sqrt(term1 + term2 + term3)
+			let varianceFactor = (term1 + term2 + term3).squareRoot()
 			let forecastSE = standardError * varianceFactor
 
 			let margin = zScoreValue * forecastSE
@@ -907,7 +907,7 @@ public struct ExponentialTrend<T: Real & Sendable>: TrendModel, Sendable {
 		let sumSquaredResiduals = residuals.map { $0 * $0 }.reduce(T.zero, +)
 		let degreesOfFreedom = max(residuals.count - 2, 1)
 		let mse = sumSquaredResiduals / T(degreesOfFreedom)
-		let standardError = sqrt(mse)
+		let standardError = mse.squareRoot()
 
 		// Get z-score for confidence level
 		let zScoreValue = zScore(ci: confidenceLevel)
@@ -925,7 +925,7 @@ public struct ExponentialTrend<T: Real & Sendable>: TrendModel, Sendable {
 			let term1 = T(1)
 			let term2 = T(1) / n
 			let term3 = (horizon * horizon) / (T(12) * n)
-			let varianceFactor = sqrt(term1 + term2 + term3)
+			let varianceFactor = (term1 + term2 + term3).squareRoot()
 			let forecastSE = standardError * varianceFactor
 
 			let margin = zScoreValue * forecastSE
@@ -1311,7 +1311,7 @@ public struct LogisticTrend<T: Real & Sendable>: TrendModel, Sendable {
 		let sumSquaredResiduals = residuals.map { $0 * $0 }.reduce(T.zero, +)
 		let degreesOfFreedom = max(residuals.count - 3, 1)  // -3 for logistic parameters
 		let mse = sumSquaredResiduals / T(degreesOfFreedom)
-		let standardError = sqrt(mse)
+		let standardError = mse.squareRoot()
 
 		// Get z-score for confidence level
 		let zScoreValue = zScore(ci: confidenceLevel)
@@ -1330,7 +1330,7 @@ public struct LogisticTrend<T: Real & Sendable>: TrendModel, Sendable {
 			let term1 = T(1)
 			let term2 = T(1) / n
 			let term3 = (horizon * horizon) / (T(12) * n)
-			let varianceFactor = sqrt(term1 + term2 + term3)
+			let varianceFactor = (term1 + term2 + term3).squareRoot()
 			let forecastSE = standardError * varianceFactor
 
 			let margin = zScoreValue * forecastSE


### PR DESCRIPTION
## Problem
The free `sqrt(_:)` function on `Float` and generic `T: Real` resolves via Darwin's math overlays on Apple platforms, but Android's Bionic libm only exposes `sqrt(Double)`. When cross-compiling to Android, `sqrt(floatValue)` / `sqrt(genericT)` fails to type-check (`cannot convert value of type 'T'/'Float' to expected argument type 'Double'`).

These were the **only 4 files (out of 1025)** that failed to compile BusinessMath for `aarch64-unknown-linux-android24`.

## Fix
Replace free `sqrt(x)` with `x.squareRoot()` — a `FloatingPoint` protocol method that is always available, needs no import, and is bit-identical to `sqrt`. This matches the portable `T.exp`/`T.log` forms `TrendModel` already uses elsewhere.

Files:
- `Simulation/distributionTriangular.swift` (×2)
- `Statistics/Comparison Statistics/nemenyiCD.swift` (×1)
- `Statistics/Regression/MatrixOperations/DenseMatrix.swift` (×1)
- `Time Series/Growth/TrendModel.swift` (×6)

## Validation
Verified by cross-compiling to `aarch64-unknown-linux-android24`: with this change, all of BusinessMath (minus the crypto-gated Fluent-API templates) compiles for Android. No behavior change on Apple platforms (`.squareRoot()` ≡ `sqrt`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)